### PR TITLE
Escape spaces in urls; Use response codes and handle relative locatio…

### DIFF
--- a/src/main/java/net/dries007/cmd/Helper.java
+++ b/src/main/java/net/dries007/cmd/Helper.java
@@ -67,17 +67,30 @@ public class Helper
     {
         for (int i = 0; i < MAX_REDIRECTS; i++)
         {
+            url = url.replace(" ", "%20");
             HttpURLConnection con = null;
             try
             {
-                con = (HttpURLConnection) new URL(url).openConnection();
+                URL objURL = new URL(url);
+                con = (HttpURLConnection) objURL.openConnection();
                 con.setInstanceFollowRedirects(false);
                 con.connect();
-                if (con.getHeaderField("Location") == null)
-                {
-                    return url.replace("?cookieTest=1", "");
+                int code = con.getResponseCode();
+                String newUrl = null;
+                if (code == 200) {
+                    return url;
                 }
-                url = con.getHeaderField("Location");
+                if (code >= 300 && code < 400) {
+                    newUrl = con.getHeaderField("Location");
+                }
+                if (newUrl == null)
+                {
+                    url = url.replace("?cookieTest=1", "");
+                } else if (newUrl.charAt(0) == '/') {
+                    url = objURL.getProtocol()+"://"+objURL.getAuthority()+newUrl;
+                } else {
+                    url = newUrl;
+                }
             }
             catch (IOException e)
             {


### PR DESCRIPTION
…ns in url connection responses

A recent change to the CurseForge website has changed the location attribute of redirect responses from full URLs to just the URL path if the protocol and domain are the same as the request. `getFinalURL` fails to handle these redirects.

I have amended it to check the response code and if it is 200, then return the original request URL. If the response is in the 3XX range then the response location is checked for a leading slash and is prefixed with the request protocol and authority (domain:port). The loop will continue until a 200 is returned or the number of redirects is exceeded.

There is also quick fix for URLs with spaces in them.