### PR TITLE
Url fix for downloading mods

### DIFF
--- a/src/main/java/net/dries007/cmd/Helper.java
+++ b/src/main/java/net/dries007/cmd/Helper.java
@@ -52,7 +52,7 @@ public class Helper
 
     public static String getFileURL(String projectName, int fileId) throws IOException
     {
-        String pre = "https://minecraft.curseforge.com/projects/" + projectName + "/files/" + fileId + "/download";
+        String pre = "https://www.curseforge.com/minecraft/mc-mods/" + projectName + "/download/" + fileId + "/file";
         String post = getFinalURL(pre);
         return pre.equals(post) ? null : post;
     }


### PR DESCRIPTION
Curse changed the URL route for mod downloads. The old one now returns a download page and doesn't redirect.

Tested with RAD 1.27 and all mods were downloaded. Not sure how this will affect other download types (e.g. resource packs).